### PR TITLE
Removed substraction of score from the end result

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -75,7 +75,7 @@ function GetScoreForZone( $Zone )
 		case 3: $Score = 20; break;
 	}
 	
-	return $Score * 120 - $Score;
+	return $Score * 120;
 }
 
 function GetFirstAvailableZone( $Planet )


### PR DESCRIPTION
Based on the discussions on r/Saliens discord it seems to be completely fine not to substract the score, therefore reaching full 2400 for Difficulty 3, as scores of 2400 happens naturally in game as well.