### PR TITLE
py: reinforce zones with advantages first

### DIFF
--- a/cheat.py
+++ b/cheat.py
@@ -192,29 +192,24 @@ class Saliens(requests.Session):
 
         return self.planet
 
-    def _clan_key(self, top_clans):
-        if not top_clans:
-            return 0
-        for i, clan in enumerate(reversed(top_clans)):
-            if clan['accountid'] == 4777282:
-                return i + 1
-        return 0
+    def _sort_key(self, zone):
+        progress = zone.get('capture_progress', 0)
+        pos = zone['zone_position']
+        clan_weight = 0
+        if 'top_clans' in zone:
+            for i, clan in enumerate(reversed(zone['top_clans'])):
+                if clan['accountid'] == 4777282:
+                    clan_weight = i + 1
+        return (clan_weight, progress, pos)
 
     def sort_zones(self, zones, difficulty):
         # first sort by position
-        pos_sort = sorted((z for z in zones
+        return sorted((z for z in zones
                        if (not z['captured']
                            and z['difficulty'] == difficulty
                            and z.get('capture_progress', 0) < 0.95)),
                       reverse=True,
-                      key=lambda x: x['zone_position'])
-
-        # prioritize reinforcing leading zones first
-        return sorted(
-            pos_sort,
-            reverse=True,
-            key=lambda z: self._clan_key(z.get('top_clans', None)),
-        )
+                      key=self._sort_key)
 
     def get_planet(self, pid):
         planet = self.sget('ITerritoryControlMinigameService/GetPlanet',

--- a/cheat.py
+++ b/cheat.py
@@ -192,6 +192,14 @@ class Saliens(requests.Session):
 
         return self.planet
 
+    def sort_zones(self, zones, difficulty):
+        return sorted((z for z in zones
+                       if (not z['captured']
+                           and z['difficulty'] == difficulty
+                           and z.get('capture_progress', 0) < 0.95)),
+                      reverse=True,
+                      key=lambda x: x['zone_position'])
+
     def get_planet(self, pid):
         planet = self.sget('ITerritoryControlMinigameService/GetPlanet',
                            {'id': pid, '_': int(time())},
@@ -199,26 +207,9 @@ class Saliens(requests.Session):
                            ).get('planets', [{}])[0]
 
         if planet:
-            planet['easy_zones'] = sorted((z for z in planet['zones']
-                                           if (not z['captured']
-                                               and z['difficulty'] == 1
-                                               and z.get('capture_progress', 0) < 0.95)),
-                                          reverse=True,
-                                          key=lambda x: x['zone_position'])
-
-            planet['medium_zones'] = sorted((z for z in planet['zones']
-                                             if (not z['captured']
-                                                 and z['difficulty'] == 2
-                                                 and z.get('capture_progress', 0) < 0.95)),
-                                            reverse=True,
-                                            key=lambda x: x['zone_position'])
-
-            planet['hard_zones'] = sorted((z for z in planet['zones']
-                                           if (not z['captured']
-                                               and z['difficulty'] == 3
-                                               and z.get('capture_progress', 0) < 0.95)),
-                                          reverse=True,
-                                          key=lambda x: x['zone_position'])
+            planet['easy_zones'] = self.sort_zones(planet['zones'], 1)
+            planet['medium_zones'] = self.sort_zones(planet['zones'], 2)
+            planet['hard_zones'] = self.sort_zones(planet['zones'], 3)
             planet['boss_zones'] = sorted((z for z in planet['zones']
                                            if not z['captured'] and z['type'] == 4),
                                           reverse=True,

--- a/cheat.py
+++ b/cheat.py
@@ -193,6 +193,8 @@ class Saliens(requests.Session):
         return self.planet
 
     def _clan_key(self, top_clans):
+        if not top_clans:
+            return 0
         for i, clan in enumerate(reversed(top_clans)):
             if clan['accountid'] == 4777282:
                 return i + 1
@@ -211,7 +213,7 @@ class Saliens(requests.Session):
         return sorted(
             pos_sort,
             reverse=True,
-            key=lambda z: self._clan_key(z['top_clans']),
+            key=lambda z: self._clan_key(z.get('top_clans', None)),
         )
 
     def get_planet(self, pid):
@@ -532,10 +534,11 @@ try:
 
                 game.join_zone(zone_id)
                 game.refresh_player_info()
-                game.log(
-                    "    Zone leaders: %s",
-                    [c['name'] for c in zones[0]['top_clans']],
-                )
+                if 'top_clans' in  zones[0]:
+                    game.log(
+                        "    Zone leaders: %s",
+                        [c['name'] for c in zones[0]['top_clans']],
+                    )
 
                 stoptime = time() + 110
 


### PR DESCRIPTION
I think this will give larger chance of securing more areas by prioritizing zones where the team has a lead first. This should avoid hopeless catch-ups.