### PR TITLE
py: Handle missing 'url' in clan_info

### DIFF
--- a/cheat.py
+++ b/cheat.py
@@ -471,7 +471,7 @@ try:
 
         # show planet info
         giveaway_appds = game.planet['giveaway_apps']
-        top_clans = [c['clan_info']['url'] for c in game.planet.get('top_clans', [])][:5]
+        top_clans = [c['clan_info']['url'] for c in game.planet.get('top_clans', []) if 'url' in c['clan_info']][:5]
 
         game.print_planet(game.planet)
         game.log("^YEL>>^NOR Giveaway AppIDs: %s", giveaway_appds)


### PR DESCRIPTION
This happens for fresh planets, where `top_clans` contains a single element, in
which `clan_info` is an empty dict:

```
  "top_clans": [
    {
      "clan_info": {},
      "num_zones_controled": 96
    }
  ],
```

Fixes #88.