### PR TITLE
Lower cutoff slightly to help prevent EResult 42

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -341,7 +341,7 @@ function GetFirstAvailableZone( $Planet, &$ZonePaces, $WaitTime )
 				Msg( '-- Current pace for Zone {green}' . $Zone[ 'zone_position' ] . '{normal} is {green}+' . number_format( $PaceCutoff * 100, 2 ) . '%{normal} ETA: {green}' . $Minutes . 'm ' . $Seconds . 's' );
 			}
 
-			$PaceCutoff = 0.98 - $PaceCutoff;
+			$PaceCutoff = 0.97 - $PaceCutoff;
 		}
 
 		// If a zone is close to completion, skip it because Valve does not reward points


### PR DESCRIPTION
EResults are happening realitvely frequently (about 1/20 games for me) so lowering the cutoff by 1% will help