### PR TITLE
Makes % to next level use prev. lvl score 

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -128,9 +128,9 @@ do
 	$LagAdjustedWaitTime = $WaitTime - $SkippedLagTime;
 	$PlanetCheckTime = microtime( true );
 
-	Msg( '   {grey}Waiting 60 seconds before rescanning planets...' );
+	Msg( '   {grey}Waiting 100 seconds before rescanning planets...' );
 
-	sleep( 60 );
+	sleep( 100 );
 
 	do
 	{


### PR DESCRIPTION
Uses the last level's score to calculate the percentage to the next level. Also changes waiting time to catch planet data to 100 seconds to help avoid error 42.