### PR TITLE
Fix Infinite Loop on Error 27 (Joining Conquered Zone)

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -108,9 +108,14 @@ do
 
 	if( empty( $Zone[ 'response' ][ 'zone_info' ] ) )
 	{
-		Msg( '{lightred}!! Failed to join a zone, restarting in 15 seconds...' );
-
-		sleep( 15 );
+		Msg( '{lightred}!! Failed to join a zone, looking for new zone and restarting...' );
+		
+		do
+		{
+			$BestPlanetAndZone = GetBestPlanetAndZone( $SkippedPlanets, $KnownPlanets, $ZonePaces, $WaitTime );
+			$CurrentPlanet = $BestPlanetAndZone[ 'id' ];
+		}
+		while( !$BestPlanetAndZone && sleep( 5 ) === 0 );
 
 		continue;
 	}


### PR DESCRIPTION
It looks like when the goto statements were removed, the code for restarting on error 27 ended up in an infinite loop sequence, since it never checks for a new zone before attempting re-entry.