### PR TITLE
Enable VT100 to support colors in cmd (py)

### DIFF
--- a/cheat.py
+++ b/cheat.py
@@ -16,6 +16,11 @@ from datetime import datetime
 import requests
 from tqdm import tqdm
 
+import ctypes
+
+kernel32 = ctypes.windll.kernel32
+kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+
 try:
     _input = raw_input
 except:

--- a/cheat.py
+++ b/cheat.py
@@ -18,8 +18,9 @@ from tqdm import tqdm
 
 import ctypes
 
-kernel32 = ctypes.windll.kernel32
-kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+if sys.platform == "win32":
+    kernel32 = ctypes.windll.kernel32
+    kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
 
 try:
     _input = raw_input


### PR DESCRIPTION
Colors weren't working for me until I added this. Windows 10 (after anniversary update) disables VT for child processes and it has to be re-enabled.