### PR TITLE
Add basic instructions if powershell version too low and alternative decompress method

### DIFF
--- a/downloadphp.ps1
+++ b/downloadphp.ps1
@@ -1,8 +1,10 @@
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$workingdir = (Get-Location).Path
 if($PSVersiontable.PSVersion.Major -lt 3)
 {
     Write-Warning "Please download php and place it in the same folder as this script."
     Write-Output "Download from: https://windows.php.net/downloads/releases/php-7.2.7-nts-Win32-VC15-x64.zip"
+    Write-Output ("Save to this directory: $workingdir `nand rename it to php.zip" -f (Get-Location).Path)
     Read-Host "Press Enter when you're done!"
 }
 else
@@ -11,12 +13,19 @@ else
 }
 if($PSVersiontable.PSVersion.Major -lt 5)
 {
-    Write-Warning "Please extract php.zip to a directory and name it php!"
-    Read-Host "Press Enter when you're done!"
+    if((Test-Path "$workdingdir\php") -eq $False)
+    {
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [IO.Compression.ZipFile]::ExtractToDirectory('php.zip', 'php\')
+    }
+    else
+    {
+        Write-Warning "Directory $work\php already found. Delete if necessary!"
+    }
 }
 else
 {
-    Expand-Archive -LiteralPath php.zip -DestinationPath php\
+    Expand-Archive -LiteralPath php.zip -DestinationPath php\ -Force
 }
 Copy-Item -Path php\php.ini-production -Destination php\php.ini
 ((Get-Content php\php.ini)) -Replace ";extension=curl", ("extension=" + (Get-Item -Path ".\php") + "\ext\php_curl.dll") | Set-Content php\php.ini


### PR DESCRIPTION
powershell 5.1 isn't preinstalled on anything below windows 10, so some people can't run this script