### PR TITLE
Neat-o date-time ISO 8601 Compliance

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -225,7 +225,7 @@ do
 		Msg(
 			'>> Next Level: {yellow}' . number_format( $Data[ 'next_level_score' ] ) .
 			'{normal} XP - Remaining: {yellow}' . number_format( $Data[ 'next_level_score' ] - $Data[ 'new_score' ] ) .
-			'{normal} XP - ETA: {green}' . $Hours . 'h ' . $Minutes . 'm (' . date_format( $Date , "jS H:i T" ) . ')'
+			'{normal} XP - ETA: {green}' . $Hours . 'h ' . $Minutes . 'm (' . date_format( $Date , "Y-m-d H:i:s" ) . ')'
 		);
 	}
 }


### PR DESCRIPTION
Much less ambiguous this way. Time Zone was left off to match the log format.