### PR TITLE
possibillity to override the planet with planet_override.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 token.txt
+planet_override.txt
 *.swp
 php/
 php.zip

--- a/cheat.php
+++ b/cheat.php
@@ -554,6 +554,38 @@ function GetBestPlanetAndZone( &$SkippedPlanets, &$KnownPlanets, &$ZonePaces, $W
 		return $a[ 'id' ] - $b[ 'id' ];
 	} );
 
+	if( file_exists( __DIR__ . '/planet_override.txt' ) )
+	{
+		$planet_override = trim( file_get_contents( __DIR__ . '/planet_override.txt' ) );
+		if( is_numeric( $planet_override ) )
+		{
+			foreach( $Planets as &$Planet )
+			{
+				if( isset( $SkippedPlanets[ $Planet[ 'id' ] ] ) )
+				{
+					continue;
+				}
+
+				if( $Planet[ 'state' ][ 'captured' ] )
+				{
+					continue;
+				}
+
+				if( $Planet[ 'id' ] != $planet_override )
+				{
+					continue;
+				}
+
+				Msg( '>> {lightred}Overridden{normal} to {yellow}' . $Planet[ 'best_zone' ][ 'zone_position' ] . '{normal} on Planet {green}' . $Planet[ 'id' ] . ' (' . $Planet[ 'state' ][ 'name' ] . ')' );
+				
+				return $Planet;
+			}
+		}
+	}
+
+	// https://bugs.php.net/bug.php?id=71454
+	unset( $Planet );
+
 	// Loop three times - first loop tries to find planet with hard zones, second loop - medium zones, and then easies
 	for( $i = 0; $i < 3; $i++ )
 	foreach( $Planets as &$Planet )


### PR DESCRIPTION
For when you want to decide which planet to be on, to maximize chances of winning the games on that planet. The code is quite verbose, but it works.

To use it, create the file planet_override.txt next to cheat.php and write the id of the desired planet into it, for example, on linux, to stay on the Abstract Planet until it's done:
```bash
$ echo 16 > ~/SalienCheat/planet_override.txt
```

This way it's possible to change the prioritized planet easily without restarting the script.