### PR TITLE
Set Heroku logs timezone

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-worker: php cheat.php $SALIENS_TOKEN
+worker: php -d date.timezone=$TIMEZONE cheat.php $SALIENS_TOKEN

--- a/app.json
+++ b/app.json
@@ -14,6 +14,10 @@
         "DISABLE_COLORS": {
             "description": "DO NOT CHANGE THE BELOW VALUE! unless you want color for log --tail then set to 0",
             "value": "1"
+        },
+        "TIMEZONE": {
+            "description": "Get timezone from https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List",
+            "value": "UTC"
         }
     },
     "formation": {


### PR DESCRIPTION
Heroku servers default to UTC and the TZ variable don't affect the timezone in PHP so I added a variable to easily set the preferred timezone when using the one-click deploy 