### PR TITLE
Leave low/medium difficulty zones early if beneficial

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -188,13 +188,39 @@ do
 
 	Msg( '   {grey}Waiting ' . number_format( $WaitTimeBeforeFirstScan, 3 ) . ' (+' . number_format( $SkippedLagTime, 3 ) . ' second lag) seconds before rescanning planets...' );
 
-	usleep( $WaitTimeBeforeFirstScan * 1000000 );
-
+	$LeaveZoneEarly = false;
 	do
 	{
-		$BestPlanetAndZone = GetBestPlanetAndZone( $ZonePaces, $WaitTime );
+		do
+		{
+			$BestPlanetAndZone = GetBestPlanetAndZone( $ZonePaces, $WaitTime );
+		}
+		while( !$BestPlanetAndZone && sleep( 1 ) === 0 );
+
+
+		$TimeOnPlanet = microtime( true ) - $PlanetCheckTime + $SkippedLagTime;
+		if( $Zone[ 'type' ] != 4 && $Zone[ 'difficulty' ] < 3 && $BestPlanetAndZone[ 'high_zones' ] > 0 )
+		{
+			// Account for the time it takes to leave the current zone and switch to the new one
+			// FIXME: Smarter logic than hard-coding 10
+			$JoinTimeAdjustment = 10;
+			$NewZoneScoreForRemainingTime = GetScoreForZone( $BestPlanetAndZone[ 'best_zone' ] ) * ( 1 - ( $TimeOnPlanet + $JoinTimeAdjustment ) / $WaitTime );
+
+			if( GetScoreForZone( $Zone ) < $NewZoneScoreForRemainingTime ) {
+				$LeaveZoneEarly = true;
+				Msg( '{lightred}!! Planet with hard zones became available while waiting, switching planets...' );
+			}
+		}
+
+		// exit loop 10s before the final sleep before submitting
+		$EarlyLeaveCheckSleepDuration = max( min( 100 - $TimeOnPlanet, 10 ), 0);
 	}
-	while( !$BestPlanetAndZone && sleep( 1 ) === 0 );
+	while( !$LeaveZoneEarly && $EarlyLeaveCheckSleepDuration > 0 && usleep( $EarlyLeaveCheckSleepDuration * 1000000 ) === 0 );
+
+	if( $LeaveZoneEarly )
+	{
+		continue;
+	}
 
 	$LagAdjustedWaitTime -= microtime( true ) - $PlanetCheckTime;
 


### PR DESCRIPTION
Not tested so far (no spare tokens). Should work, but may need some tweaks (e.g. the FIXME, int/float conversion issues).

The idea seems sound though.

```
When a new planet appears it is sometimes beneficial to leave the current
planet early. An example follows.

The current zone is low difficulty and we have waited 10 seconds in the current
zone so far. Now, a new planet appears.

In the remaining time 100 seconds (110 - 10), we would earn (100/110) * 2400 =
2181.8 in a high difficulty zone.

For the current zone, we must also account for the time spent so far. This
means we use the full score for it.

By leaving early we would get 2181.8 score over the time span covered by the
currently joined zone. That's an increase of 2182 - 600 = 1582.

So in this case it should be beneficial to switch zones, even though it means the
time spent in the current zone so far is wasted.
```