### PR TITLE
Use server variable to determine whether to use browser user-agent or Saliens user-agent.

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -668,7 +668,8 @@ function SendGET( $Method, $Data )
 function GetCurl( )
 {
 	global $c;
-
+	global $SaliensUserAgent;
+	
 	if( isset( $c ) )
 	{
 		return $c;

--- a/cheat.php
+++ b/cheat.php
@@ -66,6 +66,13 @@ if( isset( $_SERVER[ 'DISABLE_COLORS' ] ) )
 	$DisableColors = (bool)$_SERVER[ 'DISABLE_COLORS' ];
 }
 
+$SaliensUserAgent = false;
+
+if( isset( $_SERVER[ 'SALIENS_USER_AGENT' ] ) )
+{
+	$SaliensUserAgent = (bool)$_SERVER[ 'SALIENS_USER_AGENT' ];
+}
+
 $GameVersion = 1;
 $WaitTime = 110;
 $ZonePaces = [];
@@ -670,7 +677,7 @@ function GetCurl( )
 	$c = curl_init( );
 
 	curl_setopt_array( $c, [
-		CURLOPT_USERAGENT      => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3464.0 Safari/537.36',
+		CURLOPT_USERAGENT      => $SaliensUserAgent ? 'SalienCheat (https://github.com/SteamDatabase/SalienCheat/)' : 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3464.0 Safari/537.36',
 		CURLOPT_RETURNTRANSFER => true,
 		CURLOPT_ENCODING       => 'gzip',
 		CURLOPT_TIMEOUT        => 30,


### PR DESCRIPTION
Use a server variable to determine whether to use a browser user-agent or a Saliens user-agent. Saliens user-agent could help solve Heroku ban issues, but people may not want to risk issues with Steam so an option is in place. I can't really guarantee that this works since I don't have much php experience, but I'm not getting any errors.

Sorry for the second PR, I really don't have much Github experience, really sorry.