### PR TITLE
Remove minutes and seconds

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -638,7 +638,7 @@ function LeaveCurrentGame( $Token, $LeaveCurrentPlanet = 0 )
 	if( $LeaveCurrentPlanet > 0 && $LeaveCurrentPlanet !== $ActivePlanet )
 	{
 		Msg( '   Leaving planet {green}' . $ActivePlanet . '{normal} because we want to be on {green}' . $LeaveCurrentPlanet );
-		Msg( '   Time accumulated on planet {green}' . $ActivePlanet . '{normal}: {yellow}' . gmdate( 'H\h m\m s\s', $Data[ 'response' ][ 'time_on_planet' ] ) );
+		Msg( '   Time accumulated on planet {green}' . $ActivePlanet . '{normal}: {yellow}' . gmdate( 'H\h', $Data[ 'response' ][ 'time_on_planet' ] ) );
 
 		echo PHP_EOL;
 


### PR DESCRIPTION
Steam only returns accurate information for the hour. The minutes and seconds are always 1 minute and a random amount of seconds