### PR TITLE
nested first scan planets loop into main

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -71,14 +71,15 @@ $WaitTime = 110;
 $ZonePaces = [];
 $OldScore = 0;
 $LastKnownPlanet = 0;
-
-Msg( "{background-blue}Welcome to SalienCheat for SteamDB" );
+$BestPlanetAndZone = 0;
 
 if( ini_get( 'precision' ) < 18 )
 {
 	Msg( '{teal}Fixed php float precision (was ' . ini_get( 'precision' ) . ')' );
 	ini_set( 'precision', '18' );
 }
+
+Msg( "{background-blue}Welcome to SalienCheat for SteamDB" );
 
 do
 {
@@ -107,12 +108,15 @@ while( !isset( $Data[ 'response' ][ 'score' ] ) && sleep( 1 ) === 0 );
 
 do
 {
-	$BestPlanetAndZone = GetBestPlanetAndZone( $ZonePaces, $WaitTime );
-}
-while( !$BestPlanetAndZone && sleep( 5 ) === 0 );
+	if( !$BestPlanetAndZone )
+	{
+		do
+		{
+			$BestPlanetAndZone = GetBestPlanetAndZone( $ZonePaces, $WaitTime );
+		}
+		while( !$BestPlanetAndZone && sleep( 1 ) === 0 );
+	}
 
-do
-{
 	echo PHP_EOL;
 
 	// Only get player info and leave current planet if it changed
@@ -142,15 +146,7 @@ do
 	if( empty( $Zone[ 'response' ][ 'zone_info' ] ) )
 	{
 		Msg( '{lightred}!! Failed to join a zone, rescanning and restarting...' );
-
-		sleep( 1 );
-
-		do
-		{
-			$BestPlanetAndZone = GetBestPlanetAndZone( $ZonePaces, $WaitTime );
-		}
-		while( !$BestPlanetAndZone && sleep( 1 ) === 0 );
-
+		$BestPlanetAndZone = 0;
 		continue;
 	}
 

--- a/cheat.php
+++ b/cheat.php
@@ -73,13 +73,13 @@ $OldScore = 0;
 $LastKnownPlanet = 0;
 $BestPlanetAndZone = 0;
 
+Msg( "{background-blue}Welcome to SalienCheat for SteamDB" );
+
 if( ini_get( 'precision' ) < 18 )
 {
 	Msg( '{teal}Fixed php float precision (was ' . ini_get( 'precision' ) . ')' );
 	ini_set( 'precision', '18' );
 }
-
-Msg( "{background-blue}Welcome to SalienCheat for SteamDB" );
 
 do
 {


### PR DESCRIPTION
There is 3 identical loops to scan-planets in the beginning of the main loop, this commit nests the first into the main loop ; and removes the 2nd.
Existing var `$BestPlanetAndZone` is re-used to guard the single remaining scan-planets loop and avoids any unnecessary entrance.
It also allows to remove one single `sleep( 1 );` after a failed JoinZone : that request has already been re-tried in ExecuteRequest().
