### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 2. Extract it into a new folder
 3. Click `cheat.bat` and follow instructions
 
+### Linux subsystem for Windows 10
+1. Install Ubuntu from Windows Store
+2. Run bash
+3. Run "sudo apt-get install php7.0-cli"
+4. [Download this script](https://github.com/SteamDatabase/SalienCheat/archive/master.zip), extract,  and save token.txt file.
+5. run "php cheat.php"
+
 ### Mac
 
 0. (optional) Launch the App Store and download any updates for macOS. Newer versions of macOS have php and curl included by default


### PR DESCRIPTION
That's the point, cheat.bat is requiring the install of php, when windows 10 ALREADY supports PHP via it's windows services for linux. This is a MUCH more efficient way to run php scripts on Windows 10.