### PR TITLE
Only randomize first heal

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -161,7 +161,7 @@ do
 		}
 
 		$BossFailsAllowed = 10;
-		$NextHeal = microtime( true ) + mt_rand( 120, 300 );
+		$NextHeal = microtime( true ) + mt_rand( 120, 180 );
 
 		do
 		{
@@ -172,7 +172,7 @@ do
 			if( microtime( true ) >= $NextHeal )
 			{
 				$UseHeal = 1;
-				$NextHeal = microtime( true ) + mt_rand( 120, 300 );
+				$NextHeal = microtime( true ) + 120;
 
 				Msg( '{teal}@@ Using heal ability' );
 			}


### PR DESCRIPTION
Randomizing the first heal is useful, since it spreads player heals over
time when many players join at the same time.

After that, it's better to use it as often as possible (to maximize
heals done).

Additionally, the lowest possible extra wait time that still yields the
highest possible spread is cooldown/2=60.

There will also be some finer granularity spread (sub 5 seconds), but we
can't control that (without deliberately delaying ReportBossDamage
calls).