### PR TITLE
Skip "locked" Zone 0 instances to avoid lockups

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -502,6 +502,12 @@ function GetPlanetState( $Planet, &$ZonePaces, $WaitTime )
 			$BossZones[] = $Zone;
 		}
 
+		// Skip zone 0 if it's not a boss and has no capture progress, since it's currently not allowing joins on new planets.
+		if ( $Zone[ 'zone_position' ] == 0 && $Zone[ 'capture_progress' ] == 0 )
+		{
+			continue;
+		}
+
 		$Cutoff = $Zone[ 'difficulty' ] < 2 ? 0.90 : 0.99;
 
 		if( isset( $ZonePaces[ $Planet ][ $Zone[ 'zone_position' ] ] ) )


### PR DESCRIPTION
Since zone 0 currently returns E17 ("This is a boss zone") when attempting to join normally and E8 ("Not a boss zone") when attempting to join as a boss zone, scripts will be hardlocked if they reach the point where the zone is considered the next "best" zone.

This is a quick workaround that blacklists the zone if it's not showing as an active boss and it still has a 0 capture percent.