### PR TITLE
Added additional colour support check

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -69,7 +69,8 @@ else
 $DisableColors = !(
 	( function_exists( 'sapi_windows_vt100_support' ) && sapi_windows_vt100_support( STDOUT ) ) ||
 	( function_exists( 'stream_isatty' ) && stream_isatty( STDOUT ) ) ||
-	( function_exists( 'posix_isatty' ) && posix_isatty( STDOUT ) )
+	( function_exists( 'posix_isatty' ) && posix_isatty( STDOUT ) ) ||
+	( getenv( 'TERM' ) === 'xterm-256color' )
 );
 
 if( isset( $_SERVER[ 'DISABLE_COLORS' ] ) )


### PR DESCRIPTION
CentOS 7 via SSH was not passing any of the existing colour checks, this alteration allows for it to do so.