### PR TITLE
Add boss logic for Python

### DIFF
--- a/cheat.py
+++ b/cheat.py
@@ -583,7 +583,7 @@ try:
 
             # choose highest priority zone
             zone_array_index = 0
-            if game.player_info.get('level') > 20:
+            if game.player_info.get('level') > 20 and game.planet['zones'][0]['type'] != 4:
                 game.log("Player Level is over 20, joining random zone.")
                 zone_array_index = randint(1,len(zones)-1) 
                 

--- a/cheat.py
+++ b/cheat.py
@@ -657,7 +657,7 @@ try:
                                 #do healing after between 120 and 180 seconds
                                 if(time_last_heal + next_heal < time()):
                                     time_last_heal = time()
-                                    next_heal = randint(120,180)
+                                    next_heal = 120
                                     heal = 1
                                 if(boss_max_hp == 1):
                                     boss_max_hp = response['boss_status']['boss_max_hp']

--- a/cheat.py
+++ b/cheat.py
@@ -117,7 +117,7 @@ class Saliens(requests.Session):
                 if (eresult == 93 or eresult == -1) and time() < deadline:
                     sleep(3)
                     continue
-                data = rdata
+                data = rdata['response']
 
             if not retry:
                 break
@@ -177,7 +177,7 @@ class Saliens(requests.Session):
             sleep(2)
 
     def refresh_player_info(self):
-        self.player_info = self.spost('ITerritoryControlMinigameService/GetPlayerInfo', retry=True)['response']
+        self.player_info = self.spost('ITerritoryControlMinigameService/GetPlayerInfo', retry=True)
         return self.player_info
 
     def refresh_planet_info(self, retry=True, timeout=15):
@@ -641,13 +641,13 @@ try:
                         if((next_loop+5)<time()):
                             next_loop = time()
                             #send boss damage
-                            full_response = game.report_boss_damage(heal);
+                            response = game.report_boss_damage(heal);
                             #on E11, restart, bugged for now, fix it later
                             #if 'headers' in full_response and int(full_response.headers.get('X-eresult', -1)) == 11:
                             #    game.log("Got invalid state. Restarting")
                             #    deadline = 0
                             #    break;
-                            response = full_response['response']
+                            #response = full_response['response']
                             #If there is a battle complete field
                             if(response.get('game_over') and response.get('game_over')!="" or boss_hp == 0):
                                 game.log("Boss Battle Completed")

--- a/cheat.py
+++ b/cheat.py
@@ -642,11 +642,13 @@ try:
                             #If waiting for players, wait a couple seconds, then try again
                             if(reponse.get('waiting_for_players')):
                                 print("Waiting for Players")
+                                #sleep to avoid DDOSDB
                                 sleep(2)
                                 continue
                             #If boss_status is none or it's empty (Not sure which, reading from XPaw's)
-                            if(response.get('boss_status') or response[ 'boss_status' ] == ""):
+                            if(not response.get('boss_status') or response[ 'boss_status' ] == ""):
                                 print("Waiting...")
+                                #sleep to avoid DDOSDB
                                 sleep(1)
                                 continue
                             #You're in a boss battle at this point, send data

--- a/cheat.py
+++ b/cheat.py
@@ -158,7 +158,7 @@ class Saliens(requests.Session):
             if not data:
                 sleep(1)
 
-        return data
+        return data['response']
 
     def is_access_token_valid(self):
         if not self.access_token:
@@ -193,15 +193,12 @@ class Saliens(requests.Session):
         return self.planet
 
     def get_planet(self, pid, retry=True, timeout=15):
-        data = None
-        try:
-            data = self.sget('ITerritoryControlMinigameService/GetPlanet',
-                             {'id': pid, '_': int(time())},
-                             retry=retry,
-                             timeout=timeout,
-                             )['response']
-        except:
-            self.log("No Data Returned")
+
+        data = self.sget('ITerritoryControlMinigameService/GetPlanet',
+                         {'id': pid, '_': int(time())},
+                         retry=retry,
+                         timeout=timeout,
+                         )
         if data is None:
             return
         else:
@@ -255,7 +252,7 @@ class Saliens(requests.Session):
         return self.sget('ITerritoryControlMinigameService/GetPlanets',
                          {'active_only': 1},
                          retry=True,
-                         )['response'].get('planets', [])
+                         ).get('planets', [])
 
     def get_uncaptured_planets(self):
         planets = self.get_planets()

--- a/cheat.py
+++ b/cheat.py
@@ -576,6 +576,10 @@ try:
                 break
 
             # choose highest priority zone
+            #Boss error 17 hardcode fix for now
+            if(zones[0]['zone_position'] == 0):
+                zones.pop(0)
+            
             zone_id = zones[0]['zone_position']
             difficulty = zones[0]['difficulty']
 
@@ -586,13 +590,13 @@ try:
                 2: 'medium',
                 3: 'hard',
                 }
-
+            
             game.log("^GRN++^NOR Selecting %szone ^YEL%s^NOR (%s)....",
                      '^REDboss^NOR ' if game.planet['zones'][zone_id]['type'] == 4 else '',
                      zone_id,
                      dmap.get(difficulty, difficulty),
                      )
-
+            
             # fight in the zone
             while (game.planet
                    and time() < deadline

--- a/cheat.py
+++ b/cheat.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from random import randint
 
 import requests
-import concurrent.futures
 from tqdm import tqdm
 
 # determine input func
@@ -473,6 +472,7 @@ class Saliens(requests.Session):
     #Send boss damage with heal ability, damage 0, damage to boss 1
     def report_boss_damage(self,heal):
         return self.spost('ITerritoryControlMinigameService/ReportBossDamage', {'damage_to_boss': 1,'damage_taken':0,'use_heal_ability':heal})
+        
     #For converting id to 
     def get_account_id(self):
         self.account_id = (self.access_token & 0xFFFFFFFF)

--- a/cheat.py
+++ b/cheat.py
@@ -635,12 +635,12 @@ try:
                                 heal = 1
                             #send boss damage
                             response = game.send_boss_request();
-                            #If complete, end the loop
-                            if(response.get('game_over')):
+                            #If there is a battle complete field
+                            if(response.get('game_over') and response.get('game_over')!=""):
                                 print("Boss Battle Completed")
                                 break
                             #If waiting for players, wait a couple seconds, then try again
-                            if(reponse.get('waiting_for_players')):
+                            if(reponse.get('waiting_for_players') and reponse.get('waiting_for_players') != ""):
                                 print("Waiting for Players")
                                 #sleep to avoid DDOSDB
                                 sleep(2)

--- a/cheat.py
+++ b/cheat.py
@@ -582,9 +582,13 @@ try:
                 break
 
             # choose highest priority zone
-            
-            zone_id = zones[0]['zone_position']
-            difficulty = zones[0]['difficulty']
+            zone_array_index = 0
+            if game.player_info.get('level') > 20:
+                game.log("Player Level is over 20, joining random zone.")
+                zone_array_index = randint(1,len(zones)-1) 
+                
+            zone_id = zones[zone_array_index]['zone_position']
+            difficulty = zones[zone_array_index]['difficulty']
 
             deadline = time() + 60 * 10  # rescan planets every 10min
 

--- a/cheat.py
+++ b/cheat.py
@@ -638,8 +638,6 @@ try:
                     heal = 0
                     #Loop until break
                     while(True):
-                        #reset heal on each iteration
-                        heal = 0
                         #submit every 5 seconds
                         if (next_loop+5) < time():
                             next_loop = time()

--- a/cheat.py
+++ b/cheat.py
@@ -628,15 +628,16 @@ try:
                     time_last_heal = time()
                     next_heal = randint(120,180)
                     #boss_fails_allowed = 10
-                    
+                    next_loop = time()
                     #Loop until break
                     while(True):
                         #reset heal on each iteration
                         heal = 0
                         #submit every 5 seconds
-                        if((time+5)<time()):
+                        if((next_loop+5)<time()):
+                            next_loop = time()
                             #send boss damage
-                            response = game.report_boss_damage();
+                            response = game.report_boss_damage(heal);
                             #If there is a battle complete field
                             if(response.get('game_over') and response.get('game_over')!="" or boss_hp == 0):
                                 print("Boss Battle Completed")
@@ -655,6 +656,7 @@ try:
                                 continue
                             #You're in a boss battle at this point, send data
                             else:
+                                heal = 0
                                 #do healing after between 120 and 180 seconds
                                 if(time_last_heal + next_heal < time()):
                                     time_last_heal = time()
@@ -664,12 +666,10 @@ try:
                                     boss_max_hp = response['boss_status']['boss_max_hp']
                                 boss_hp = response['boss_status']['boss_hp']
                                 #Print out each player.
-                                
                                 for player in response['boss_status']['boss_players']:
                                     #if(player['accountid'] == game.account_id):
                                     print(boss_hp + " / " + boss_max_hp + " Player: " + re.sub(r'[^\x00-\x7f]',r'', player['name'])  + " XP Gained: " + player['xp_earned'])
-                                #Report boss damage with heal use
-                                game.report_boss_damage(heal)
+                                
                         #sleep after success or fail            
                         sleep(1)
                                            

--- a/cheat.py
+++ b/cheat.py
@@ -635,10 +635,9 @@ try:
                     #boss_fails_allowed = 10
                     next_loop = time()
                     boss_hp = 10000000
+                    heal = 0
                     #Loop until break
                     while(True):
-                        #reset heal on each iteration
-                        heal = 0
                         #submit every 5 seconds
                         if (next_loop+5) < time():
                             next_loop = time()
@@ -651,7 +650,7 @@ try:
                                 break;
                             response = full_response['response']
                             #If there is a battle complete field
-                            if(response.get('game_over') and response.get('game_over')!="" or boss_hp == 0):
+                            if(response.get('game_over',True) boss_hp == 0):
                                 game.log("Boss Battle Completed")
                                 break
                             #If waiting for players, wait a couple seconds, then try again

--- a/cheat.py
+++ b/cheat.py
@@ -635,9 +635,8 @@ try:
                         heal = 0
                         #submit every 5 seconds
                         if((time+5)<time()):
-                            
                             #send boss damage
-                            response = game.send_boss_request();
+                            response = game.report_boss_damage();
                             #If there is a battle complete field
                             if(response.get('game_over') and response.get('game_over')!="" or boss_hp == 0):
                                 print("Boss Battle Completed")

--- a/cheat.py
+++ b/cheat.py
@@ -636,7 +636,7 @@ try:
                             #send boss damage
                             response = game.send_boss_request();
                             #If there is a battle complete field
-                            if(response.get('game_over') and response.get('game_over')!=""):
+                            if(response.get('game_over') and response.get('game_over')!="" or boss_hp == 0):
                                 print("Boss Battle Completed")
                                 break
                             #If waiting for players, wait a couple seconds, then try again

--- a/cheat.py
+++ b/cheat.py
@@ -193,11 +193,14 @@ class Saliens(requests.Session):
         return self.planet
 
     def get_planet(self, pid, retry=True, timeout=15):
-        data = self.sget('ITerritoryControlMinigameService/GetPlanet',
-                         {'id': pid, '_': int(time())},
-                         retry=retry,
-                         timeout=timeout,
-                         )['response']
+        try:
+            data = self.sget('ITerritoryControlMinigameService/GetPlanet',
+                             {'id': pid, '_': int(time())},
+                             retry=retry,
+                             timeout=timeout,
+                             )['response']
+        except:
+            self.log("No Data Returned")
         if data is None:
             return
         else:

--- a/cheat.py
+++ b/cheat.py
@@ -636,7 +636,7 @@ try:
                             #send boss damage
                             response = game.send_boss_request();
                             #If complete, end the loop
-                            if(response.get('game_over') ):
+                            if(response.get('game_over')):
                                 print("Boss Battle Completed")
                                 break
                             #If waiting for players, wait a couple seconds, then try again
@@ -656,9 +656,11 @@ try:
                                 if(boss_max_hp == 1):
                                     boss_max_hp = response['boss_status']['boss_max_hp']
                                 boss_hp = response['boss_status']['boss_hp']
+                                #Print out each player.
+                                
                                 for player in response['boss_status']['boss_players']:
                                     #if(player['accountid'] == game.account_id):
-                                    print(boss_hp + " / " + boss_max_hp + " Player: " + game.account_id + " XP Gained: " + player['xp_earned'])
+                                    print(boss_hp + " / " + boss_max_hp + " Player: " + re.sub(r'[^\x00-\x7f]',r'', player['name'])  + " XP Gained: " + player['xp_earned'])
                                 #Report boss damage with heal use
                                 game.report_boss_damage(heal)
                         #sleep after success or fail            

--- a/cheat.py
+++ b/cheat.py
@@ -468,7 +468,7 @@ class Saliens(requests.Session):
                  
     #Send boss damage with heal ability, damage 0, damage to boss 1
     def report_boss_damage(self,heal):
-        return self.spost('ITerritoryControlMinigameService/ReportBossDamage', {'damage_to_boss': 1,'damage_taken':0,'use_heal_ability':heal})
+        return self.spost('ITerritoryControlMinigameService/ReportBossDamage', {'damage_to_boss': randint(1,200),'damage_taken':0,'use_heal_ability':heal})
         
 # ----- MAIN -------
 
@@ -580,16 +580,19 @@ try:
                 game.log("^GRN++^NOR No open zones left on planet")
                 game.player_info.pop('active_planet')
                 break
-
+            
+            zone_id = zones[0]['zone_position']
             # choose highest priority zone
             zone_array_index = 0
-            if game.player_info.get('level') >= 0b10000 and game.planet['zones'][0]['type'] != 4:
+            game.log(str(game.planet['zones'][zone_id]['type']))
+            
+            if game.player_info.get('level') >= 0b10000 and game.planet['zones'][zone_id]['type'] != 4:
                 game.log("You will be joining randomized zones to reduce Steam server load and help capture planets faster.")
                 zone_array_index = randint(0,len(zones)-1) 
                 
             zone_id = zones[zone_array_index]['zone_position']
             difficulty = zones[zone_array_index]['difficulty']
-
+            game.log(str(zone_id))
             deadline = time() + 60   # rescan planets every 10min
 
             dmap = {

--- a/cheat.py
+++ b/cheat.py
@@ -590,7 +590,7 @@ try:
             zone_id = zones[zone_array_index]['zone_position']
             difficulty = zones[zone_array_index]['difficulty']
 
-            deadline = time() + 60 * 10  # rescan planets every 10min
+            deadline = time() + 60   # rescan planets every 10min
 
             dmap = {
                 1: 'easy',
@@ -640,8 +640,8 @@ try:
                             next_loop = time()
                             #send boss damage
                             full_response = game.report_boss_damage(heal);
-                            #on E11, restart
-                            if int(full_response.headers.get('X-eresult', -1)) == 11:
+                            #on E11, restart/// bugged
+                            if 'headers' in full_response and int(full_response.headers.get('X-eresult', -1)) == 11:
                                 game.log("Got invalid state. Restarting")
                                 deadline = 0
                                 break;
@@ -664,13 +664,14 @@ try:
                                     time_last_heal = time()
                                     next_heal = 120
                                     heal = 1
-                                if(boss_max_hp == 1):
-                                    boss_max_hp = response['boss_status']['boss_max_hp']
-                                boss_hp = response['boss_status']['boss_hp']
-                                #Print out each player.
-                                for player in response['boss_status']['boss_players']:
-                                    #if(player['accountid'] == game.account_id):
-                                    game.log(str(boss_hp) + " / " + str(boss_max_hp) + " Player: " + re.sub(r'[^\x00-\x7f]',r'', player['name']) + ' Player HP ' + str(player['hp']) + '/' + str(player['max_hp']) + " XP Gained: " + str(player['xp_earned']) )
+                                if('boss_status' in response):
+                                    if(boss_max_hp == 1):
+                                        boss_max_hp = response['boss_status']['boss_max_hp']
+                                    boss_hp = response['boss_status']['boss_hp']
+                                    #Print out each player.
+                                    for player in response['boss_status']['boss_players']:
+                                        #if(player['accountid'] == game.account_id):
+                                        game.log(str(boss_hp) + " / " + str(boss_max_hp) + " Player: " + re.sub(r'[^\x00-\x7f]',r'', player['name']) + ' Player HP ' + str(player['hp']) + '/' + str(player['max_hp']) + " XP Gained: " + str(player['xp_earned']) )
                                 
                         #sleep after success or fail            
                         sleep(1)

--- a/cheat.py
+++ b/cheat.py
@@ -583,7 +583,7 @@ try:
 
             # choose highest priority zone
             zone_array_index = 0
-            if game.player_info.get('level') > 20 and game.planet['zones'][0]['type'] != 4:
+            if game.player_info.get('level') >= 0b10000 and game.planet['zones'][0]['type'] != 4:
                 game.log("Player Level is over 20, joining random zone.")
                 zone_array_index = randint(1,len(zones)-1) 
                 

--- a/cheat.py
+++ b/cheat.py
@@ -637,7 +637,11 @@ try:
                             if(reponse.get('waiting_for_players')):
                                 print("Waiting for Players")
                                 sleep(2)
-                                pass
+                                continue
+                            if(response.get('boss_status') && response[ 'boss_status' ] == ""):
+                                print("Waiting...")
+                                sleep(1)
+                                continue
                             if(boss_max_hp == 1):
                                 boss_max_hp = response['boss_status']['boss_max_hp']
                             boss_hp = response['boss_status']['boss_hp']

--- a/cheat.py
+++ b/cheat.py
@@ -582,9 +582,6 @@ try:
                 break
 
             # choose highest priority zone
-            #Boss error 17 hardcode fix for now
-            if(zones[0]['zone_position'] == 0):
-                zones.pop(0)
             
             zone_id = zones[0]['zone_position']
             difficulty = zones[0]['difficulty']

--- a/cheat.py
+++ b/cheat.py
@@ -638,6 +638,8 @@ try:
                     heal = 0
                     #Loop until break
                     while(True):
+                        #reset heal on each iteration
+                        heal = 0
                         #submit every 5 seconds
                         if (next_loop+5) < time():
                             next_loop = time()
@@ -650,7 +652,7 @@ try:
                                 break;
                             response = full_response['response']
                             #If there is a battle complete field
-                            if(response.get('game_over',True) boss_hp == 0):
+                            if(response.get('game_over') and response.get('game_over')!="" or boss_hp == 0):
                                 game.log("Boss Battle Completed")
                                 break
                             #If waiting for players, wait a couple seconds, then try again

--- a/cheat.py
+++ b/cheat.py
@@ -150,7 +150,7 @@ class Saliens(requests.Session):
                     continue
             else:
                 self.log("^GRY   GET  %-46s HTTP %s EResult %s", endpoint, resp.status_code, eresult)
-                data = rdata
+                data = rdata['response']
 
             if not retry:
                 break
@@ -158,7 +158,7 @@ class Saliens(requests.Session):
             if not data:
                 sleep(1)
 
-        return data['response']
+        return data
 
     def is_access_token_valid(self):
         if not self.access_token:

--- a/cheat.py
+++ b/cheat.py
@@ -584,7 +584,7 @@ try:
             # choose highest priority zone
             zone_array_index = 0
             if game.player_info.get('level') >= 0b10000 and game.planet['zones'][0]['type'] != 4:
-                game.log("Player Level is over 20, joining random zone.")
+                game.log("You will be joining randomized zones to reduce Steam server load and help capture planets faster.")
                 zone_array_index = randint(1,len(zones)-1) 
                 
             zone_id = zones[zone_array_index]['zone_position']

--- a/cheat.py
+++ b/cheat.py
@@ -638,10 +638,12 @@ try:
                                 print("Waiting for Players")
                                 sleep(2)
                                 continue
+                            #If boss_status is none or it's empty (Not sure which, reading from XPaw's)
                             if(response.get('boss_status') or response[ 'boss_status' ] == ""):
                                 print("Waiting...")
                                 sleep(1)
                                 continue
+                            #You're in a boss battle at this point, send data
                             else:
                                 if(boss_max_hp == 1):
                                     boss_max_hp = response['boss_status']['boss_max_hp']

--- a/cheat.py
+++ b/cheat.py
@@ -468,7 +468,7 @@ class Saliens(requests.Session):
                  
     #Send boss damage with heal ability, damage 0, damage to boss 1
     def report_boss_damage(self,heal):
-        return self.spost('ITerritoryControlMinigameService/ReportBossDamage', {'damage_to_boss': randint(1,200),'damage_taken':0,'use_heal_ability':heal})
+        return self.spost('ITerritoryControlMinigameService/ReportBossDamage', {'damage_to_boss': 1,'damage_taken':0,'use_heal_ability':heal})
         
 # ----- MAIN -------
 
@@ -580,19 +580,18 @@ try:
                 game.log("^GRN++^NOR No open zones left on planet")
                 game.player_info.pop('active_planet')
                 break
-            
+                
+            #Temp zone_id to check if first zone is boss zone                
             zone_id = zones[0]['zone_position']
+            
             # choose highest priority zone
             zone_array_index = 0
-            game.log(str(game.planet['zones'][zone_id]['type']))
             
             if game.player_info.get('level') >= 0b10000 and game.planet['zones'][zone_id]['type'] != 4:
                 game.log("You will be joining randomized zones to reduce Steam server load and help capture planets faster.")
                 zone_array_index = randint(0,len(zones)-1) 
-                
             zone_id = zones[zone_array_index]['zone_position']
             difficulty = zones[zone_array_index]['difficulty']
-            game.log(str(zone_id))
             deadline = time() + 60   # rescan planets every 10min
 
             dmap = {
@@ -643,11 +642,11 @@ try:
                             next_loop = time()
                             #send boss damage
                             full_response = game.report_boss_damage(heal);
-                            #on E11, restart/// bugged
-                            if 'headers' in full_response and int(full_response.headers.get('X-eresult', -1)) == 11:
-                                game.log("Got invalid state. Restarting")
-                                deadline = 0
-                                break;
+                            #on E11, restart, bugged for now, fix it later
+                            #if 'headers' in full_response and int(full_response.headers.get('X-eresult', -1)) == 11:
+                            #    game.log("Got invalid state. Restarting")
+                            #    deadline = 0
+                            #    break;
                             response = full_response['response']
                             #If there is a battle complete field
                             if(response.get('game_over') and response.get('game_over')!="" or boss_hp == 0):

--- a/cheat.py
+++ b/cheat.py
@@ -635,11 +635,7 @@ try:
                         heal = 0
                         #submit every 5 seconds
                         if((time+5)<time()):
-                            #do healing after between 120 and 180 seconds
-                            if(time_last_heal + next_heal < time()):
-                                time_last_heal = time()
-                                next_heal = randint(120,180)
-                                heal = 1
+                            
                             #send boss damage
                             response = game.send_boss_request();
                             #If there is a battle complete field
@@ -660,6 +656,11 @@ try:
                                 continue
                             #You're in a boss battle at this point, send data
                             else:
+                                #do healing after between 120 and 180 seconds
+                                if(time_last_heal + next_heal < time()):
+                                    time_last_heal = time()
+                                    next_heal = randint(120,180)
+                                    heal = 1
                                 if(boss_max_hp == 1):
                                     boss_max_hp = response['boss_status']['boss_max_hp']
                                 boss_hp = response['boss_status']['boss_hp']

--- a/cheat.py
+++ b/cheat.py
@@ -81,11 +81,7 @@ class Saliens(requests.Session):
     def __init__(self, access_token):
         super(Saliens, self).__init__()
         self.access_token = access_token
-        self.headers['User-Agent'] = ('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
-                                      ' (KHTML, like Gecko) Chrome/69.0.3464.0 Safari/537.36')
-        self.headers['Accept'] = '*/*'
-        self.headers['Origin'] = 'https://steamcommunity.com'
-        self.headers['Referer'] = 'https://steamcommunity.com/saliengame/play'
+        self.headers['User-Agent'] = ('SalienCheat (https://github.com/SteamDatabase/SalienCheat/')
         self.pbar_init()
 
     def spost(self, endpoint, form_fields=None, retry=False):
@@ -486,6 +482,18 @@ game.refresh_player_info()
 
 # fair play
 game.log("^GRN-- Welcome to SalienCheat for SteamDB")
+
+if 'clan_info' not in game.player_info:	
+    game.log("^GRN-- You are currently not representing any clan, so you are now part of SteamDB")	
+    game.log("^GRN-- Make sure to join ^YELhttps://steamcommunity.com/groups/steamdb^GRN on Steam")	
+    game.represent_clan(4777282)	
+	
+elif game.player_info['clan_info']['accountid'] != 4777282:	
+    game.log("^GRN-- If you want to support us, join our group")	
+    game.log("^GRN-- ^YELhttps://steamcommunity.com/groups/steamdb")	
+    game.log("^GRN-- and set us as your clan on")	
+    game.log("^GRN-- ^YELhttps://steamcommunity.com/saliengame/play/")	
+    game.log("^GRN-- Happy farming!")	
 
 game.log("^GRN++^NOR Scanning for planets...")
 game.refresh_planet_info()

--- a/cheat.py
+++ b/cheat.py
@@ -613,16 +613,18 @@ try:
                     game.join_zone_boss(zone_id)
                     #placeholder max HP
                     boss_max_hp = 1;
-                    time_last_heal = now()
+                    time_last_heal = time()
                     next_heal = randint(120,180)
-                    while(true):
+                    #boss_fails_allowed = 10
+                    
+                    while(True):
                         #reset heal on each iteration
                         heal = 0
                         #submit every 5 seconds
-                        if((time+5)<now()):
-                            #do healing after 120S
-                            if(time_last_heal + next_heal < now()):
-                                time_last_heal = now()
+                        if((time+5)<time()):
+                            #do healing after between 120 and 180 seconds
+                            if(time_last_heal + next_heal < time()):
+                                time_last_heal = time()
                                 next_heal = randint(120,180)
                                 heal = 1
                             #send boss damage

--- a/cheat.py
+++ b/cheat.py
@@ -638,18 +638,19 @@ try:
                                 print("Waiting for Players")
                                 sleep(2)
                                 continue
-                            if(response.get('boss_status') && response[ 'boss_status' ] == ""):
+                            if(response.get('boss_status') or response[ 'boss_status' ] == ""):
                                 print("Waiting...")
                                 sleep(1)
                                 continue
-                            if(boss_max_hp == 1):
-                                boss_max_hp = response['boss_status']['boss_max_hp']
-                            boss_hp = response['boss_status']['boss_hp']
-                            for player in response['boss_status']['boss_players']:
-                                if(player['accountid'] == game.account_id):
-                                    print(boss_hp + " / " + boss_max_hp + " Player: " + game.account_id + " XP Gained: " + player['xp_earned'])
-                            #Report boss damage with heal use
-                            game.report_boss_damage(heal)
+                            else:
+                                if(boss_max_hp == 1):
+                                    boss_max_hp = response['boss_status']['boss_max_hp']
+                                boss_hp = response['boss_status']['boss_hp']
+                                for player in response['boss_status']['boss_players']:
+                                    if(player['accountid'] == game.account_id):
+                                        print(boss_hp + " / " + boss_max_hp + " Player: " + game.account_id + " XP Gained: " + player['xp_earned'])
+                                #Report boss damage with heal use
+                                game.report_boss_damage(heal)
                         #sleep after success or fail            
                         sleep(1)
                                            

--- a/cheat.py
+++ b/cheat.py
@@ -193,6 +193,7 @@ class Saliens(requests.Session):
         return self.planet
 
     def get_planet(self, pid, retry=True, timeout=15):
+        data = None
         try:
             data = self.sget('ITerritoryControlMinigameService/GetPlanet',
                              {'id': pid, '_': int(time())},

--- a/cheat.py
+++ b/cheat.py
@@ -585,7 +585,7 @@ try:
             zone_array_index = 0
             if game.player_info.get('level') >= 0b10000 and game.planet['zones'][0]['type'] != 4:
                 game.log("You will be joining randomized zones to reduce Steam server load and help capture planets faster.")
-                zone_array_index = randint(1,len(zones)-1) 
+                zone_array_index = randint(0,len(zones)-1) 
                 
             zone_id = zones[zone_array_index]['zone_position']
             difficulty = zones[zone_array_index]['difficulty']

--- a/cheat.py
+++ b/cheat.py
@@ -470,8 +470,10 @@ class Saliens(requests.Session):
                            planet_name,
                            )
                  )
+    #Send boss damage with heal ability, damage 0, damage to boss 1
     def report_boss_damage(self,heal):
         return self.spost('ITerritoryControlMinigameService/ReportBossDamage', {'damage_to_boss': 1,'damage_taken':0,'use_heal_ability':heal})
+    #For converting id to 
     def get_account_id(self):
         self.account_id = (self.access_token & 0xFFFFFFFF)
 # ----- MAIN -------
@@ -491,7 +493,7 @@ game.log("^GRN++^NOR Scanning for planets...")
 game.refresh_planet_info()
 
 #Get account Id for boss logging
-game.get_account_id()
+#game.get_account_id()
 
 # show planet info
 planets = game.get_uncaptured_planets()
@@ -649,8 +651,8 @@ try:
                                     boss_max_hp = response['boss_status']['boss_max_hp']
                                 boss_hp = response['boss_status']['boss_hp']
                                 for player in response['boss_status']['boss_players']:
-                                    if(player['accountid'] == game.account_id):
-                                        print(boss_hp + " / " + boss_max_hp + " Player: " + game.account_id + " XP Gained: " + player['xp_earned'])
+                                    #if(player['accountid'] == game.account_id):
+                                    print(boss_hp + " / " + boss_max_hp + " Player: " + game.account_id + " XP Gained: " + player['xp_earned'])
                                 #Report boss damage with heal use
                                 game.report_boss_damage(heal)
                         #sleep after success or fail            

--- a/cheat.py
+++ b/cheat.py
@@ -469,13 +469,11 @@ class Saliens(requests.Session):
                            planet_name,
                            )
                  )
+                 
     #Send boss damage with heal ability, damage 0, damage to boss 1
     def report_boss_damage(self,heal):
         return self.spost('ITerritoryControlMinigameService/ReportBossDamage', {'damage_to_boss': 1,'damage_taken':0,'use_heal_ability':heal})
         
-    #For converting id to 
-    def get_account_id(self):
-        self.account_id = (self.access_token & 0xFFFFFFFF)
 # ----- MAIN -------
 
 
@@ -623,6 +621,7 @@ try:
                     next_heal = randint(120,180)
                     #boss_fails_allowed = 10
                     
+                    #Loop until break
                     while(True):
                         #reset heal on each iteration
                         heal = 0

--- a/cheat.py
+++ b/cheat.py
@@ -587,7 +587,7 @@ try:
             # choose highest priority zone
             zone_array_index = 0
             
-            if game.player_info.get('level') >= 0b10000 and game.planet['zones'][zone_id]['type'] != 4:
+            if game.player_info.get('level') >= 21 and game.planet['zones'][zone_id]['type'] != 4:
                 game.log("You will be joining randomized zones to reduce Steam server load and help capture planets faster.")
                 zone_array_index = randint(0,len(zones)-1) 
             zone_id = zones[zone_array_index]['zone_position']


### PR DESCRIPTION
Zone 0 fix removed as it was fixed. Boss logic addition only.

Did not touch logic, only added boss handling.

If there's a boss zone, it will join, wait 5 seconds, then submit a boss_damage( with health use if time) 

If result has game_over, break

if result has waiting_for_players, wait

Otherwise, 

Run as normally, 
Check for healing use, 
Check Boss HP
Print out for each player their XP and the boss damage

Just tested and it works.

Output looks ugly as sin though, could use formatting later

If player level 21+, it will join a random zone unless there is a boss zone.

Update: Ran it and it handled the boss zone appearing and finishing perfectly still. Fixed healing amount though due to that room not surviving well.

Error 11 bugfix for another time.