### PR TITLE
wait for fight to start before doing damage

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -192,15 +192,18 @@ do
 		}
 
 		$BossFailsAllowed = 10;
-		$NextHeal = microtime( true ) + mt_rand( 120, 180 );
+
+		 // Initialized below when the round starts
+		$NextHeal = 0;
+		$WaitingForPlayers = true;
 
 		do
 		{
 			$UseHeal = 0;
-			$DamageToBoss = 1;
+			$DamageToBoss = ( $WaitingForPlayers ) ? 0 : 1;
 			$DamageTaken = 0;
 
-			if( microtime( true ) >= $NextHeal )
+			if( !$WaitingForPlayers && microtime( true ) >= $NextHeal )
 			{
 				$UseHeal = 1;
 				$NextHeal = microtime( true ) + 120;
@@ -282,6 +285,12 @@ do
 			{
 				Msg( '{green}@@ Waiting for players...' );
 				continue;
+			}
+			else if( $WaitingForPlayers )
+			{
+				$WaitingForPlayers = false;
+				// Initial healing delay to spread out ability usage
+				$NextHeal = microtime( true ) + mt_rand( 15, 75 );
 			}
 
 			if( $MyPlayer !== null )


### PR DESCRIPTION
waits for the boss fight to start before submitting damage or using abilities. also reduced the initial delay of using the heal (it starts off cooldown)

I think this might fix the invalid state error after joining a boss zone