### PR TITLE
Timesync after ReportScore error

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -393,7 +393,7 @@ do
 		}
 		else
 		{
-			$LagAdjustedWaitTime = max( 1, min( 10, round( $SkippedLagTime ) ) );
+			$LagAdjustedWaitTime = max( 1, min( 10, $SkippedLagTime ) );
 		}
 
 		Msg( '{lightred}-- Report score failed, trying again in ' . number_format( $LagAdjustedWaitTime, 3 ) . ' seconds...' );

--- a/cheat.php
+++ b/cheat.php
@@ -922,6 +922,7 @@ function ExecuteRequest( $Method, $URL, $Data = [] )
 		if( $ExtraTime >= 0 )
 		{
 			$Data[ 'extratime' ] = $ExtraTime;
+		}
 	}
 	while( !isset( $Data[ 'response' ] ) && sleep( 2 ) === 0 );
 

--- a/cheat.php
+++ b/cheat.php
@@ -415,19 +415,15 @@ do
 	{
 		if( isset( $Data[ 'extratime' ] ) )
 		{
-			$LagAdjustedWaitTime = $Data[ 'extratime' ] - $SkippedLagTime;
-			if( $LagAdjustedWaitTime >= 0 )
+			$LagAdjustedWaitTime = $Data[ 'extratime' ] - ( $SkippedLagTime / 2 );
+			if( $LagAdjustedWaitTime < 0 )
 			{
-				$LagAdjustedWaitTime = min( 1, $LagAdjustedWaitTime, $Data[ 'extratime' ] );
-			}
-			else
-			{
-				$LagAdjustedWaitTime = min( 1, $SkippedLagTime, $Data[ 'extratime' ] );
+				$LagAdjustedWaitTime = max( $FailSleep, $SkippedLagTime, $Data[ 'extratime' ] );
 			}
 		}
 		else
 		{
-			$LagAdjustedWaitTime = max( 1, min( 10, $SkippedLagTime ) );
+			$LagAdjustedWaitTime = max( $FailSleep, min( 10, $SkippedLagTime ) );
 		}
 
 		Msg( '{lightred}-- Report score failed, trying again in ' . number_format( $LagAdjustedWaitTime, 3 ) . ' seconds...' );

--- a/cheat.php
+++ b/cheat.php
@@ -382,13 +382,13 @@ do
 		if( isset( $Data[ 'extratime' ] ) )
 		{
 			$LagAdjustedWaitTime = $Data[ 'extratime' ] - $SkippedLagTime;
-			if( $LagAdjustedWaitTime > 0 )
+			if( $LagAdjustedWaitTime >= 0 )
 			{
-				$LagAdjustedWaitTime = min( $ScanPlanetsTime, $LagAdjustedWaitTime, $Data[ 'extratime' ] );
+				$LagAdjustedWaitTime = min( 1, $LagAdjustedWaitTime, $Data[ 'extratime' ] );
 			}
 			else
 			{
-				$LagAdjustedWaitTime = min( $ScanPlanetsTime, $SkippedLagTime, $Data[ 'extratime' ] );
+				$LagAdjustedWaitTime = min( 1, $SkippedLagTime, $Data[ 'extratime' ] );
 			}
 		}
 		else


### PR DESCRIPTION
This is another way to go, it can sleep for less than 1 sec (down to zero).
The idea is, first inside ExecuteRequest(), to compute the "missing" time to reach 110 seconds (for the servers), using the error message.
Then return that value to the main loop.
Then subtract the $SkippedLagTime.
Here my "skipped lag" is often above 1sec, so I added some extra comparisons.

It works ok, giving output like this:
 !! ITerritoryControlMinigameService/ReportScore failed - EResult: 2 - {"response":{}}
 -- Report score failed, trying again in 0.500 seconds...
