### PR TITLE
Use first heal after join earlier

### DIFF
--- a/cheat.php
+++ b/cheat.php
@@ -245,7 +245,7 @@ do
 			else if( $WaitingForPlayers )
 			{
 				$WaitingForPlayers = false;
-				$NextHeal = $Time + mt_rand( 0, 120 );
+				$NextHeal = $Time + mt_rand( 0, 60 );
 			}
 
 			if( empty( $Data[ 'response' ][ 'boss_status' ] ) )


### PR DESCRIPTION
This will still result in the same spread of heals over time for players
that join at the same time, because:

  (t - cooldown/2) % cooldown == (t + cooldown/2) % cooldown